### PR TITLE
Num parser performance

### DIFF
--- a/Barb.sln
+++ b/Barb.sln
@@ -15,6 +15,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{BF60BC93-E09B-4E5F-9D85-95A519479D54}"
 	ProjectSection(SolutionItems) = preProject
 		build.fsx = build.fsx
+		PerfComp.fsx = PerfComp.fsx
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection

--- a/PerfComp.fsx
+++ b/PerfComp.fsx
@@ -1,0 +1,60 @@
+﻿#r @"src\Barb\bin\Release\Barb.dll"
+
+open Barb.Parse
+
+let text = StringWindow("-1234.5678", 0u)
+
+let result = match text with | Num x -> x
+let whileResult = match text with | WhileNum x -> x
+let recResult = match text with | RecNum x -> x
+
+let limit = 1L * 1000L * 1000L * 10L
+
+let numbers = [0L .. limit]
+
+#time
+
+let speedTest =
+    numbers
+    |> List.map (fun x -> match text with | Num x -> x)
+
+let recSpeedTest =
+    numbers
+    |> List.map (fun x -> match text with | RecNum x -> x)
+
+let whileSpeedTest =
+    numbers
+    |> List.map (fun x -> match text with | WhileNum x -> x)
+
+
+// **** Parsing 123.456 10m times
+// Original (100%)
+// Real: 00:00:17.306, CPU: 00:00:17.815, GC gen0: 548, gen1: 149, gen2: 2
+// Recursive function p/q handling  (36.3%) (36.0%)
+// Real: 00:00:11.021, CPU: 00:00:11.403, GC gen0: 345, gen1: 126, gen2: 2
+// While loop p/q handling          (53.8%) (52.6%)
+// Real: 00:00:07.988, CPU: 00:00:08.439, GC gen0: 281, gen1: 100, gen2: 2
+
+// **** Parsing 1234.5678 10m times
+// Original (100%)
+// Real: 00:00:18.054, CPU: 00:00:18.642, GC gen0: 561, gen1: 151, gen2: 2
+// Recursive function p/q handling  (31.0%) (29.5%)
+// Real: 00:00:12.462, CPU: 00:00:13.150, GC gen0: 345, gen1: 124, gen2: 2
+// While loop p/q handling          (54.5%) (52.6%)
+// Real: 00:00:08.205, CPU: 00:00:08.829, GC gen0: 281, gen1: 100, gen2: 2
+
+// **** Parsing 123456789.123456789 10m times
+// Original (100%)
+// Real: 00:00:18.402, CPU: 00:00:19.125, GC gen0: 753, gen1: 174, gen2: 3
+// Recursive function p/q handling  (29.8%) (28.9%)
+// Real: 00:00:12.917, CPU: 00:00:13.603, GC gen0: 346, gen1: 126, gen2: 2
+// While loop p/q handling          (54.3%) (52.5%)
+// Real: 00:00:08.404, CPU: 00:00:09.079, GC gen0: 282, gen1: 100, gen2: 2
+
+// *** Parsing -1234.5678 10m times
+// Original (100%)
+// Real: 00:00:23.206, CPU: 00:00:24.024, GC gen0: 562, gen1: 150, gen2: 2
+// Recursive function p/q handling  (48.9%) (46.7%)
+// Real: 00:00:11.867, CPU: 00:00:12.792, GC gen0: 346, gen1: 126, gen2: 2
+// While loop p/q handling          (66.2%) (65.4%)
+// Real: 00:00:07.830, CPU: 00:00:08.314, GC gen0: 281, gen1: 100, gen2: 2

--- a/src/Barb/Parse.fs
+++ b/src/Barb/Parse.fs
@@ -1,4 +1,4 @@
-﻿module internal Barb.Parse
+﻿module Barb.Parse
 
 // TODO: 
 // Do ascii lookup for Num, instead of a dumb list
@@ -24,7 +24,7 @@ open Checked
 type BarbParsingException (message, offset, length) =
     inherit BarbException (message, offset, length)
 
-type internal StringWindow =
+type StringWindow =
     struct
         // These are mutable to prevent property generation.
         val mutable Text: string 


### PR DESCRIPTION
Saw "Optimized Numeric Type Handling" in the todo list in the readme, thought I'd poke around because it was Friday afternoon and I was bored. Adding this PR to give an overview of what I came up with; happy to put a proper PR together later if you want to use either of these implementations.

Minor points of note are marking `isnumchar` as inline, and replacing the `isnegative` function with a value; the [current code](https://github.com/Rickasaurus/Barb/blob/master/src/Barb/Parse.fs#L94-L96) appears to be running `isnegative` twice, even in an optimized release build.

Major differences in my code is the removal of the `StringBuilder` and calls to `Double.TryParse` and `Int64.TryParse`; I've replaced all that with tracking of the current value as a rational of `p` and `q`. After parsing, if no dot was found, `p` is returned as-is, if a dot was found, `p` and `q` are converted to `double` and divided appropriately. I'm sure there's probably some pros/cons to doing this for fractional values vs just using `Double.TryParse`.

Generated the timings provided on an i7 3770 in an iMac running Windows 7 inside parallels with 8 logical processors. Each timing was generated by resetting F# Interactive in VS to avoid GC from previous tests, then selecting and running lines 1-15 to get the parser pushed through the JIT, and then separately running the appropriate "speed test" code. YMMV :grimacing:
